### PR TITLE
Bugfix in ConnectorServer.bat

### DIFF
--- a/OpenICF-java-framework/openicf-zip/src/main/resources/bin/ConnectorServer.bat
+++ b/OpenICF-java-framework/openicf-zip/src/main/resources/bin/ConnectorServer.bat
@@ -144,7 +144,7 @@ for %%P in (%*) do (
     set T=%%P
     if "!T:~1,2!" == "%JVM_OPTION_IDENTIFIER%" (
       set JAVA_OPTS_PARAM=!JAVA_OPTS_PARAM!!JAVA_OPTS_DELIM!!T:~3,-1!
-      set JAVA_OPTS_DELIM=
+      set JAVA_OPTS_DELIM= 
     )
 )
 cd "%CONNECTOR_SERVER_HOME%"


### PR DESCRIPTION
Added a space character « » to the JAVA_OPTS_DELIM parameter of the :srvRun section of the ConnectorServer.bat file.
This space is necessary to separate Java parameters when starting server with the /run key.
If there is no separator, the parameters are concatenated into one line without spaces and simply do not work.
I encountered this bug when I tried to set up a secure connection to the OpenICF connector server via SSL. Example from usage: «ConnectorServer.bat /run "-J-Djavax.net.ssl.keyStore=keystore.jks" "-J-Djavax.net.ssl.keyStorePassword=changeit"» does not work for this reason.
I found the error very confusing, because in normal mode the connector server does not output any errors to the console related to this bug.