### PR TITLE
CVE-2019-17554 CVE-2019-17555 CVE-2020-1925 Bump Apache Olingo

### DIFF
--- a/OpenICF-groovy-connector/pom.xml
+++ b/OpenICF-groovy-connector/pom.xml
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-core</artifactId>
-            <version>4.0.0-beta-01</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- Improper Restriction of XML External Entity Reference in Apache Olingo 
- Improper input validation in Apache Olingo
- Server-Side Request Forgery (SSRF) in Apache Olingo