### PR TITLE
Fix NPE in XMLConnector.dispose() when init() failed

### DIFF
--- a/OpenICF-xml-connector/src/main/java/org/forgerock/openicf/connectors/xml/XMLConnector.java
+++ b/OpenICF-xml-connector/src/main/java/org/forgerock/openicf/connectors/xml/XMLConnector.java
@@ -21,6 +21,7 @@
  * your own identifying information:
  * "Portions Copyrighted 2010 [name of copyright owner]"
  *
+ * Portions Copyrighted 2026 3A Systems LLC
  * $Id$
  */
 package org.forgerock.openicf.connectors.xml;

--- a/OpenICF-xml-connector/src/main/java/org/forgerock/openicf/connectors/xml/XMLConnector.java
+++ b/OpenICF-xml-connector/src/main/java/org/forgerock/openicf/connectors/xml/XMLConnector.java
@@ -99,8 +99,19 @@ public class XMLConnector implements Connector, AuthenticateOp, CreateOp, Delete
      * @see org.identityconnectors.framework.spi.Connector#dispose()
      */
     public void dispose() {
-        xmlInstanceHandler.dispose();
-        log.ok("Dispose {0}", config.getXmlFilePath());
+        if (xmlInstanceHandler == null) {
+            // init() never completed successfully (e.g. invalid XML/XSD path),
+            // nothing to release. Avoid throwing NPE so the original failure
+            // from init()/operation is not masked.
+            log.ok("Dispose called but XML handler was not initialized; nothing to release");
+            return;
+        }
+        try {
+            xmlInstanceHandler.dispose();
+        } finally {
+            xmlInstanceHandler = null;
+        }
+        log.ok("Dispose {0}", config != null ? config.getXmlFilePath() : null);
     }
     
     private synchronized Object getLock() {


### PR DESCRIPTION
When `XMLConnector.init()` fails (e.g. invalid XML/XSD path), the framework still invokes `dispose()`, which dereferences the never-assigned `xmlInstanceHandler` and throws an NPE that masks the original failure cause from `test`/operation calls.

### Changes
- **`XMLConnector.dispose()`**: guard against `xmlInstanceHandler == null`, log at `ok` level and return instead of throwing.
- **Idempotency**: null out `xmlInstanceHandler` in a `finally` after `dispose()` so repeated calls are safe (consistent with `ConcurrentXMLHandler.dispose()` decrementing `invokers`).
- **Logging**: guard the `config.getXmlFilePath()` access so a pre-`init` dispose can't NPE either.

```java
public void dispose() {
    if (xmlInstanceHandler == null) {
        log.ok("Dispose called but XML handler was not initialized; nothing to release");
        return;
    }
    try {
        xmlInstanceHandler.dispose();
    } finally {
        xmlInstanceHandler = null;
    }
    log.ok("Dispose {0}", config != null ? config.getXmlFilePath() : null);
}
```
