### PR TITLE
Modernizes the OpenICF Docker images and broadens their multi-architecture build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,16 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 name: Build
 
 on:
@@ -126,7 +139,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x #, linux/arm/v7
+          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x, linux/riscv64 #, linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -135,6 +148,7 @@ jobs:
         run: |
           docker run --rm -it -d --memory="1g" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
+          docker logs test
   build-docker-alpine:
     runs-on: 'ubuntu-latest'
     services:
@@ -174,7 +188,7 @@ jobs:
           file: ./Dockerfile-alpine
           build-args: |
             VERSION=${{ env.release_version }}
-          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le, linux/386, linux/riscv64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -183,3 +197,4 @@ jobs:
         run: |
           docker run --rm -it -d --memory="1g" --name=test localhost:5000/${GITHUB_REPOSITORY,,}:${{ env.release_version }}-alpine
           timeout 3m bash -c 'until docker inspect --format="{{json .State.Health.Status}}" test | grep -q \"healthy\"; do sleep 10; done'
+          docker logs test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,16 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 name: Release
 
 on:
@@ -120,7 +133,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             VERSION=${{ github.event.inputs.releaseVersion }}
-          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x #, linux/arm/v7
+          platforms: linux/amd64, linux/arm64/8, linux/ppc64le, linux/s390x, linux/riscv64 #, linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -168,7 +181,7 @@ jobs:
           file: ./Dockerfile-alpine
           build-args: |
             VERSION=${{ github.event.inputs.releaseVersion }}
-          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le
+          platforms: linux/amd64, linux/arm64/8, linux/s390x, linux/ppc64le, linux/386, linux/riscv64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM eclipse-temurin:25-jre-jammy
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
+FROM eclipse-temurin:25-jre-noble
 
 LABEL org.opencontainers.image.authors="Open Identity Platform Community <open-identity-platform-openidm@googlegroups.com>"
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,19 +1,35 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2024-2026 3A Systems, LLC.
 FROM alpine:latest
 
 LABEL org.opencontainers.image.authors="Open Identity Platform Community"
 
 ENV USER="openicf"
-ENV OPENICF_OPTS="-server -XX:+UseContainerSupport"
+ENV OPENICF_OPTS="-server -XX:+UseContainerSupport --add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED "
 
 ARG VERSION
+
+ARG TARGETARCH
 
 WORKDIR /opt
 
 #COPY OpenICF-java-framework/openicf-zip/target/*.zip ./
 
-RUN apk add --update --no-cache --virtual builddeps curl unzip openjdk11-jre \
+RUN apk add --update --no-cache --virtual builddeps curl unzip \
  && apk upgrade --update --no-cache \
- && apk add bash \
+ && if [ "$TARGETARCH" = "386" ]; then JDK=openjdk11-jre; else JDK=openjdk25-jre; fi \
+ && apk add bash "$JDK" \
  && bash -c 'if [ ! -z "$VERSION" ] ; then rm -rf ./*.zip ; curl -L https://github.com/OpenIdentityPlatform/OpenICF/releases/download/$VERSION/openicf-$VERSION.zip --output openicf-$VERSION.zip ; fi' \
  && unzip openicf-*.zip && rm -rf *.zip \
  && apk del unzip \


### PR DESCRIPTION
## Summary

Modernizes the OpenICF Docker images and broadens their multi-architecture build matrix.

- **Ubuntu image** (`Dockerfile`): switch the base image from `eclipse-temurin:25-jre-jammy` to `eclipse-temurin:25-jre-noble` (Ubuntu 22.04 → 24.04) and add `linux/riscv64` to its build platforms.
- **Alpine image** (`Dockerfile-alpine`): add `linux/386` and `linux/riscv64`, and select the JDK per target architecture instead of hard-coding `openjdk11-jre`.
- Apply the platform changes to both the `build.yml` and `release.yml` workflows.
- Print the container log at the end of each "Docker test" step in `build.yml`.

## Platform coverage

| Image | Platforms |
|-------|-----------|
| Ubuntu / Noble (`Dockerfile`) | `linux/amd64`, `linux/arm64/8`, `linux/ppc64le`, `linux/s390x`, `linux/riscv64` |
| Alpine (`Dockerfile-alpine`) | `linux/amd64`, `linux/arm64/8`, `linux/s390x`, `linux/ppc64le`, `linux/386`, `linux/riscv64` |

## Conditional JDK on Alpine

Alpine's package repositories do not offer a single OpenJDK version that covers every target architecture:

- 32-bit `x86` (`linux/386`) only has `openjdk11` (no 32-bit build of newer JDKs).
- `riscv64` only has `openjdk21`/`openjdk25` (no `openjdk11`).

`Dockerfile-alpine` therefore declares `ARG TARGETARCH` and installs:

- `openjdk11-jre` on `linux/386`
- `openjdk25-jre` on every other architecture (aligns the Alpine runtime with the Ubuntu image's JRE 25)

## Java 25 LDAP connector flag

Because the Alpine image now runs Java 25 on every architecture except `linux/386`, its `OPENICF_OPTS` gains `--add-exports java.base/com.sun.jndi.ldap=ALL-UNNAMED`, matching the Ubuntu image. The flag is required for the LDAP connector under Java's strong encapsulation and is harmless on Java 11.

## Notes

- `linux/arm/v6` (armhf) and `linux/arm/v7` (armv7) are intentionally **not** included: Alpine ships no OpenJDK for those architectures at any version, and `eclipse-temurin` does not publish them either, so an OpenICF image cannot be produced for them.

## Testing

- `build-docker` (Ubuntu/Noble) and `build-docker-alpine` jobs build successfully across all listed platforms, including the existing "Docker test" health-check smoke test (now followed by `docker logs test`).
- JDK package selection verified per architecture: `openjdk11-jre` on `linux/386`, `openjdk25-jre` elsewhere.
