### PR TITLE
Add CodeQL code-scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,107 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 3A Systems, LLC.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+  schedule:
+    # Weekly run, Mondays at 03:27 UTC
+    - cron: '27 3 * * 1'
+  # Allows running this workflow manually from the Actions tab or via the gh CLI.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to avoid the long-running,
+# eventually-cancelled analyses seen with the previous default setup.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required to upload results to code scanning.
+      security-events: write
+      # Only needed for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # This multi-module Maven build is expensive to compile, so we use
+          # build-mode 'none': CodeQL builds its model straight from the Java
+          # sources without invoking Maven. This avoids the long,
+          # eventually-cancelled autobuild that the default setup can hit.
+          #
+          # For higher precision (dataflow through compiled dependencies) switch
+          # this to 'manual' and uncomment the "Build with Maven" step below.
+          #
+          # Note: the Groovy connector sources (*.groovy) are not covered here —
+          # CodeQL has no Groovy analyzer.
+          - language: java-kotlin
+            build-mode: none
+          # Scans the repository's own GitHub Actions workflows.
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          # Exclude test and integration-test sources. With build-mode 'none'
+          # CodeQL extracts straight from source, so paths-ignore reliably
+          # scopes the analysis.
+          config: |
+            paths-ignore:
+              - '**/src/test/**'
+              - '**/src/it/**'
+
+      # --- Manual build (only used when build-mode is 'manual') -------------
+      # - name: Set up JDK 11
+      #   uses: actions/setup-java@v5
+      #   with:
+      #     java-version: '11'
+      #     distribution: 'zulu'
+      # - name: Cache Maven packages
+      #   uses: actions/cache@v5
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.os }}-m2-repository-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-m2-repository
+      # - name: Build with Maven
+      #   env:
+      #     MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
+      #   run: mvn --batch-mode --errors -DskipTests -Dmaven.test.skip=true clean compile --file pom.xml
+      # ---------------------------------------------------------------------
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds a CodeQL code-scanning workflow, adapted for OpenICF.

### What it does
- Analyzes **java-kotlin** and **actions** (the repo's own GitHub Actions workflows).
- Uses **build-mode: `none`** — CodeQL models straight from Java sources without a Maven compile, avoiding the long, eventually-cancelled autobuild.
- Query suite: `security-and-quality`.
- Triggers: push/PR on `master`, weekly Monday cron, and manual `workflow_dispatch`.
- `concurrency` cancels superseded runs; least-privilege `permissions`; 360-min timeout.
- `paths-ignore` excludes `**/src/test/**` and `**/src/it/**`.

### Scoping notes
- No `csharp` (repo has no .NET module) and no `javascript-typescript` (only a single JS test resource) — dropped vs. the upstream reference.
- The **Groovy** connector sources are not covered — CodeQL has no Groovy analyzer.
- A commented-out `build-mode: manual` Maven block is included for switching to dataflow-through-dependencies precision later.
