### PR TITLE
CI: trim build matrix on macOS/Windows and add workflow concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,28 @@ on:
   push:
     branches: [ 'sustaining/1.8.x','master', 'issues/**', 'features/**' ]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-maven:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ 'ubuntu-latest' ]
         java: [ '11', '17', '21', '25', '26' ]
-        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        # macOS and Windows runners are the slowest and scarcest in CI, so only
+        # smoke-test the minimum (11) and maximum (26) supported JDKs on them.
+        # Ubuntu keeps the full JDK matrix above.
+        include:
+          - os: 'macos-latest'
+            java: '11'
+          - os: 'macos-latest'
+            java: '26'
+          - os: 'windows-latest'
+            java: '11'
+          - os: 'windows-latest'
+            java: '26'
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     workflows: ["Build","Release"]
     types: [completed]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches: [ 'sustaining/1.8.x','master' ]
     workflows: ["Build","Release"]
     types: [completed]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   deploy-maven:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         description: "Default version to use for new local working copy."
         required: true
         default: "X.Y.Z-SNAPSHOT"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   release-maven:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Analogous to OpenAM [#1064](https://github.com/OpenIdentityPlatform/OpenAM/pull/1064) and [#1065](https://github.com/OpenIdentityPlatform/OpenAM/pull/1065).

## Trim build matrix (like OpenAM #1064)
`build.yml` ran a full 5×3 matrix (JDK 11/17/21/25/26 × Ubuntu/macOS/Windows = 15 jobs). macOS and Windows runners are the slowest and scarcest in CI and rarely surface OS-specific issues beyond the JDK edges, so:

- Ubuntu keeps the full JDK matrix (11, 17, 21, 25, 26).
- macOS and Windows now smoke-test only the minimum (11) and maximum (26) JDKs via `include`.
- Total jobs: **15 → 9**.

## Workflow concurrency (like OpenAM #1065)
Added `concurrency` groups keyed on `${{ github.workflow }}-${{ github.ref }}`:

- `build.yml`: `cancel-in-progress: true` — a new push/PR cancels a superseded in-flight build.
- `release.yml` / `deploy.yml`: `cancel-in-progress: false` — overlapping runs queue instead of being interrupted, protecting Maven Central publishing / GitHub releases.

`codeql.yml` is intentionally left untouched.