### PR TITLE
Fix WebSocket client wedging that made OpenICFWebSocketTest flaky

### DIFF
--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
@@ -196,6 +196,12 @@ public class ClientRemoteConnectorInfoManager extends
                         }
                     }
                 });
+
+                // Stamped after the close listener is registered: once this
+                // timestamp is >= lastConnectAttempt, the permit held by the
+                // last attempt is guaranteed to be released on close, so the
+                // heartbeat self-heal must not restore it.
+                lastConnectionCreated.set(System.currentTimeMillis());
             }
         };
 
@@ -207,12 +213,19 @@ public class ClientRemoteConnectorInfoManager extends
                     }
                 }
                 // Self-heal: a connect attempt that failed before Grizzly
-                // created the Connection has no close listener to release its
-                // permit. If there is no live connection, no free permit and
-                // no recent connect attempt, restore the lost permit so the
-                // client can reconnect instead of staying wedged forever.
+                // created the Connection (openSocketChannel or
+                // obtainNIOConnection threw, e.g. fd exhaustion) has no close
+                // listener to release its permit. If there is no live
+                // connection, no free permit, no recent connect attempt and
+                // the last attempt never created a Connection
+                // (lastConnectionCreated < lastConnectAttempt), restore the
+                // lost permit so the client can reconnect instead of staying
+                // wedged forever. When a Connection exists its close listener
+                // releases the permit, so healing then would over-credit
+                // while the connection is still pending its handshake.
                 if (isRunning.get() && privateConnections.isEmpty() && !hasFreeConnectionPermit()
-                        && System.currentTimeMillis() - lastConnectAttempt.get() > 30000) {
+                        && System.currentTimeMillis() - lastConnectAttempt.get() > 30000
+                        && lastConnectionCreated.get() < lastConnectAttempt.get()) {
                     logger.ok("Restoring connection permit lost by a failed connect attempt - {0}",
                             getName());
                     tryReleaseConnectionPermit();
@@ -337,6 +350,7 @@ public class ClientRemoteConnectorInfoManager extends
 
     private final AtomicLong lastConnectithenOnException = new AtomicLong(0L);
     private final AtomicLong lastConnectAttempt = new AtomicLong(0L);
+    private final AtomicLong lastConnectionCreated = new AtomicLong(0L);
 
     public Promise<WebSocketConnectionHolder, RuntimeException> connect() {
         return connect(true);

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.client;
@@ -172,12 +174,13 @@ public class ClientRemoteConnectorInfoManager extends
                 conn.addCloseListener(new CloseListener() {
                     public void onClosed(Closeable closeable, ICloseType type) throws IOException {
                         logger.ok("DEBUG = Connection Closed {0}", type);
-                        
-                        if (availableConnectionPermitCount.get()<1) {
-                        		logger.ok("Destroy onClosed. Remaining permits: {0}", availableConnectionPermitCount.get());
-                        		return;
-                        }
-                        
+
+                        // Always give back the permit held by this connection.
+                        // Skipping the release when no permit is available
+                        // leaks the last permit of a single-connection client
+                        // and leaves it unable to reconnect forever.
+                        // tryReleaseConnectionPermit() is capped at
+                        // permittedConnectionCount so it can not over-credit.
                         tryReleaseConnectionPermit();
 
                         if (!socket.connectPromise.isDone()) {
@@ -202,6 +205,17 @@ public class ClientRemoteConnectorInfoManager extends
                     if (!ws.isOperational() || !isRunning.get()) {
                         ws.close();
                     }
+                }
+                // Self-heal: a connect attempt that failed before Grizzly
+                // created the Connection has no close listener to release its
+                // permit. If there is no live connection, no free permit and
+                // no recent connect attempt, restore the lost permit so the
+                // client can reconnect instead of staying wedged forever.
+                if (isRunning.get() && privateConnections.isEmpty() && !hasFreeConnectionPermit()
+                        && System.currentTimeMillis() - lastConnectAttempt.get() > 30000) {
+                    logger.ok("Restoring connection permit lost by a failed connect attempt - {0}",
+                            getName());
+                    tryReleaseConnectionPermit();
                 }
                 while (isRunning.get() && null != connect(false)) {
                     logger.ok("New connection is created - {0}. Remaining permits:{1}", getName(),
@@ -322,6 +336,7 @@ public class ClientRemoteConnectorInfoManager extends
     // ----
 
     private final AtomicLong lastConnectithenOnException = new AtomicLong(0L);
+    private final AtomicLong lastConnectAttempt = new AtomicLong(0L);
 
     public Promise<WebSocketConnectionHolder, RuntimeException> connect() {
         return connect(true);
@@ -367,6 +382,7 @@ public class ClientRemoteConnectorInfoManager extends
         // Successfully acquired one permit
         if (index > -1) {
             if (isRunning.get()) {
+                lastConnectAttempt.set(System.currentTimeMillis());
                 if (connectionInfo.getLocalAddress() != null) {
                     connectionHandler.connect(remoteAddress, new InetSocketAddress(connectionInfo
                             .getLocalAddress(), 0), callback);

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionGroup.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionGroup.java
@@ -90,7 +90,9 @@ public class WebSocketConnectionGroup
                 }
             };
 
-    private boolean receivedConnectorInfo = false;
+    // Written from transport callback threads, read by the scheduler in
+    // checkIsActive().
+    private volatile boolean receivedConnectorInfo = false;
     private final AtomicBoolean initialConnectorInfoRequest = new AtomicBoolean(false);
     private final RemoteConnectorInfoManager delegate = new RemoteConnectorInfoManager();
 
@@ -141,9 +143,7 @@ public class WebSocketConnectionGroup
                 }
             };
 
-            ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
-            requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
-            ControlMessageRequest request = trySubmitRequest(requestFactory);
+            ControlMessageRequest request = trySubmitRequest(connectorInfoRequestFactory());
             if (null == request) {
                 // No operational connection yet - checkIsActive() retries
                 // while receivedConnectorInfo is false.
@@ -153,9 +153,7 @@ public class WebSocketConnectionGroup
                 @Override
                 public Boolean apply(RuntimeException e) throws RuntimeException {
                     logger.ok("Resending initial 'CONNECTOR_INFO' request", e);
-                    ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
-                    requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
-                    ControlMessageRequest retry = trySubmitRequest(requestFactory);
+                    ControlMessageRequest retry = trySubmitRequest(connectorInfoRequestFactory());
                     if (null != retry) {
                         retry.getPromise().then(success);
                     }
@@ -163,6 +161,12 @@ public class WebSocketConnectionGroup
                 }
             });
         }
+    }
+
+    private static ControlMessageRequestFactory connectorInfoRequestFactory() {
+        final ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
+        requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
+        return requestFactory;
     }
 
     public void principalIsShuttingDown(final Principal connectionPrincipal) {
@@ -350,11 +354,8 @@ public class WebSocketConnectionGroup
             }
 
             if (operational) {
-                ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
-                if (!receivedConnectorInfo) {
-                    requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
-                }
-                trySubmitRequest(requestFactory);
+                trySubmitRequest(receivedConnectorInfo ? new ControlMessageRequestFactory()
+                        : connectorInfoRequestFactory());
             }
         }
         return operational || !remoteRequests.isEmpty() || !localRequests.isEmpty();

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionGroup.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionGroup.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.remote.rpc;
@@ -90,6 +91,7 @@ public class WebSocketConnectionGroup
             };
 
     private boolean receivedConnectorInfo = false;
+    private final AtomicBoolean initialConnectorInfoRequest = new AtomicBoolean(false);
     private final RemoteConnectorInfoManager delegate = new RemoteConnectorInfoManager();
 
     public WebSocketConnectionGroup(final String remoteSessionId) {
@@ -112,29 +114,55 @@ public class WebSocketConnectionGroup
             webSocketConnection.listeners.add(closeListener);
             principals.add(connectionPrincipal.getName());
             if (webSockets.indexOf(entry) == 0) {
-                ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
-                requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
-                final Function<Boolean, Boolean, RuntimeException> success = new Function<Boolean, Boolean, RuntimeException>() {
-                    @Override
-                    public Boolean apply(Boolean value) throws RuntimeException {
-                        receivedConnectorInfo = value;
-                        return receivedConnectorInfo;
-                    }
-                };
-
-                trySubmitRequest(requestFactory).getPromise().then(success, new Function<RuntimeException, Boolean, RuntimeException>() {
-                    @Override
-                    public Boolean apply(RuntimeException e) throws RuntimeException {
-                        logger.ok("Resending initial 'CONNECTOR_INFO' request", e);
-                        ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
-                        requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
-                        trySubmitRequest(requestFactory).getPromise().then(success);
-                        return receivedConnectorInfo;
-                    }
-                });
+                // The initial 'CONNECTOR_INFO' request is deferred until
+                // handshakeComplete() - sending it from here races with the
+                // response: the holder assigns its RemoteOperationContext only
+                // after this method returns, so an early response would be
+                // dropped with a NullPointerException.
+                initialConnectorInfoRequest.set(true);
             }
         }
         return operationContext;
+    }
+
+    /**
+     * Invoked by {@link WebSocketConnectionHolder#receiveHandshake} after the
+     * holder has stored the {@link RemoteOperationContext} returned by
+     * {@link #handshake(Principal, WebSocketConnectionHolder, HandshakeMessage)},
+     * so responses to the requests sent below can always be dispatched.
+     */
+    public void handshakeComplete() {
+        if (initialConnectorInfoRequest.compareAndSet(true, false)) {
+            final Function<Boolean, Boolean, RuntimeException> success = new Function<Boolean, Boolean, RuntimeException>() {
+                @Override
+                public Boolean apply(Boolean value) throws RuntimeException {
+                    receivedConnectorInfo = value;
+                    return receivedConnectorInfo;
+                }
+            };
+
+            ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
+            requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
+            ControlMessageRequest request = trySubmitRequest(requestFactory);
+            if (null == request) {
+                // No operational connection yet - checkIsActive() retries
+                // while receivedConnectorInfo is false.
+                return;
+            }
+            request.getPromise().then(success, new Function<RuntimeException, Boolean, RuntimeException>() {
+                @Override
+                public Boolean apply(RuntimeException e) throws RuntimeException {
+                    logger.ok("Resending initial 'CONNECTOR_INFO' request", e);
+                    ControlMessageRequestFactory requestFactory = new ControlMessageRequestFactory();
+                    requestFactory.infoLevels.add(InfoLevel.CONNECTOR_INFO);
+                    ControlMessageRequest retry = trySubmitRequest(requestFactory);
+                    if (null != retry) {
+                        retry.getPromise().then(success);
+                    }
+                    return receivedConnectorInfo;
+                }
+            });
+        }
     }
 
     public void principalIsShuttingDown(final Principal connectionPrincipal) {

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionHolder.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/rpc/WebSocketConnectionHolder.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.remote.rpc;
@@ -45,6 +47,14 @@ public abstract class WebSocketConnectionHolder
     public boolean receiveHandshake(HandshakeMessage message) {
         if (null == getRemoteConnectionContext()) {
             handshake(message);
+            final RemoteOperationContext context = getRemoteConnectionContext();
+            if (null != context) {
+                // The context is visible only from this point on, so the
+                // initial connector info exchange is started here instead of
+                // inside handshake(message) - a response arriving before the
+                // context is assigned would otherwise be dropped.
+                context.getRemoteConnectionGroup().handshakeComplete();
+            }
         }
         return isHandHooked();
     }

--- a/OpenICF-java-framework/connector-server-grizzly/pom.xml
+++ b/OpenICF-java-framework/connector-server-grizzly/pom.xml
@@ -22,7 +22,7 @@
  your own identifying information:
  "Portions Copyrighted [year] [name of copyright owner]"
 
-  Portions Copyrighted 2018-2025 3A Systems, LLC
+  Portions Copyrighted 2018-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -160,7 +160,7 @@
                         <exclude>**/AsyncJavaPlainConnectorInfoManagerTest.java</exclude>
                     </excludes>
                     <shutdown>kill</shutdown>
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
                 </configuration>
             </plugin>
         </plugins>

--- a/OpenICF-java-framework/connector-server-grizzly/src/test/java/org/forgerock/openicf/framework/server/OpenICFWebSocketTest.java
+++ b/OpenICF-java-framework/connector-server-grizzly/src/test/java/org/forgerock/openicf/framework/server/OpenICFWebSocketTest.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.server;
@@ -37,6 +39,7 @@ import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.forgerock.openicf.framework.ConnectorFramework;
 import org.forgerock.openicf.framework.ConnectorFrameworkFactory;
@@ -204,13 +207,17 @@ public class OpenICFWebSocketTest {
             Assert.assertNotNull(manager);
 
             ConnectorInfo c = null;
-            for (int i = 0; (c =
-                    manager.findConnectorInfoAsync(TEST_CONNECTOR_KEY).getOrThrowUninterruptibly(5,
-                            TimeUnit.MINUTES)) == null
-                    && i < 5; i++) {
-                // Wait until the connection is established and the connector
-                // info are transferred.
-                Thread.sleep(20000);
+            for (int i = 0; null == c && i < 5; i++) {
+                try {
+                    // Wait until the connection is established and the
+                    // connector info are transferred. Keep each attempt well
+                    // below the Surefire fork timeout so a hang fails this
+                    // test instead of killing the whole forked JVM.
+                    c = manager.findConnectorInfoAsync(TEST_CONNECTOR_KEY)
+                            .getOrThrowUninterruptibly(20, TimeUnit.SECONDS);
+                } catch (TimeoutException e) {
+                    Reporter.log("Connector info not received yet, retrying", true);
+                }
             }
             Assert.assertNotNull(c);
             for (ConnectorInfo ci : manager.getConnectorInfos()) {

--- a/OpenICF-java-framework/connector-server-jetty/pom.xml
+++ b/OpenICF-java-framework/connector-server-jetty/pom.xml
@@ -22,7 +22,7 @@
  your own identifying information:
  "Portions Copyrighted [year] [name of copyright owner]"
 
-  Portions Copyrighted 2018-2025 3A Systems, LLC
+  Portions Copyrighted 2018-2026 3A Systems, LLC
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -132,7 +132,7 @@
                     <reuseForks>false</reuseForks>
                     <shutdown>kill</shutdown>
                     <forkCount>1</forkCount>
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
+                    <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
                     <argLine>-Dorg.eclipse.jetty.LEVEL=DEBUG</argLine>
 <!--                    <includes>-->
 <!--                        <include>AsyncRemotePlainConnectorInfoManagerTest.java</include>-->


### PR DESCRIPTION
Fixes #102

`OpenICFWebSocketTest.testRemoteConnectorInfoManager` hung for a full 5 minutes on the macOS/JDK 26 CI runner and killed the whole `connector-server-grizzly` fork ("There was a timeout in the fork"). The root causes are unrecoverable states in the WebSocket client, detailed in #102.

## Production code (`connector-framework-server`)

- **`ClientRemoteConnectorInfoManager`**
  - `onClosed`: always release the permit held by the closing connection. The inverted `availableConnectionPermitCount < 1` guard skipped the release exactly when the closing connection held the *last* permit, leaving a single-connection client permanently unable to reconnect (heartbeat `connect(false)` and the on-demand path are both permit-gated). `tryReleaseConnectionPermit()` is already capped at `permittedConnectionCount`, so it cannot over-credit.
  - Releasing in the `failed()` callback was deliberately **not** added: per Grizzly 4.0.2 `TCPNIOConnectorHandler` sources, every failure path after `preConfigure` also closes the connection, so the close listener fires and a `failed()` release would double-credit.
  - Heartbeat self-heal for the remaining case (connect attempt failing *before* the Grizzly `Connection` exists, e.g. fd exhaustion — no close listener to release the permit): if there is no live connection, no free permit and no connect attempt for 30 s, restore the lost permit.
- **`WebSocketConnectionGroup` / `WebSocketConnectionHolder`**: the initial `CONNECTOR_INFO` request was sent from inside `handshake()`, before the holder assigned its `RemoteOperationContext` — a fast response was dispatched into `socket.getRemoteConnectionContext()` == `null` → NPE, silently dropping the connector info with no retry (the retry chain only reacts to promise *failure*). The request is now sent from a new `handshakeComplete()` hook invoked by `receiveHandshake` after the context is stored; this fixes the client, the Grizzly server and the Jetty server holders at once, since all three assign the context after `handshake()` returns. Also guarded `trySubmitRequest()` returning `null` (allowed by its contract) in the initial request and its retry.

## Tests / infra

- **`OpenICFWebSocketTest`**: the poll loop was dead code — `getOrThrowUninterruptibly` never returns `null`, so the test was a single 5-minute blocking wait. Replaced with real polling: 5 × 20-second attempts.
- **grizzly / jetty poms**: `forkedProcessTimeoutInSeconds` 300 → 900. The in-test wait (300 s) was equal to the fork timeout, so any single hang was converted into a fork kill for the whole module instead of one failed test.

## Verification

- `connector-framework-server`: 24/24 pass
- `connector-server-grizzly` (incl. `OpenICFWebSocketTest`): 32/32 pass, two consecutive runs (~51 s each vs 350 s with the hang)
- `connector-server-jetty`: 30/30 pass
- `javadoc:javadoc` (strict doclint): clean
