### PR TITLE
Fix race in BatchApiOpImpl CompletionListener.start() causing flaky IllegalThreadStateException (#105)

### DIFF
--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.async.impl;
@@ -290,7 +292,7 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
         // Flow control flags
         private final AtomicBoolean resultChannelComplete = new AtomicBoolean(false);
         private final AtomicBoolean completeEventComplete = new AtomicBoolean(false);
-        private BatchToken returnToken = null;
+        private volatile BatchToken returnToken = null;
         private final AtomicLong completionTimeout = new AtomicLong(new Date().getTime() + 5000);
         private final CompletionListener completionListener = new CompletionListener();
 
@@ -345,13 +347,16 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
             } else if (message.getTaskId().length() == 0 && !message.getComplete()) {
                 // BatchToken message (token list may be empty)
                 logger.ok("Batch token received.");
-                returnToken = new BatchToken();
+                // Fully populate the token before publishing it to the volatile field read by
+                // the CompletionListener thread.
+                BatchToken token = new BatchToken();
                 for (int i = 0; i < message.getBatchTokenCount(); i++) {
-                    returnToken.addToken(message.getBatchToken(i));
+                    token.addToken(message.getBatchToken(i));
                 }
-                returnToken.setQueryRequired(message.getQueryRequired());
-                returnToken.setAsynchronousResults(message.getAsynchronousResults());
-                returnToken.setReturnsResults(message.getReturnsResults());
+                token.setQueryRequired(message.getQueryRequired());
+                token.setAsynchronousResults(message.getAsynchronousResults());
+                token.setReturnsResults(message.getReturnsResults());
+                returnToken = token;
 
                 if (!message.getReturnsResults()) {
                     // No results returned with this token
@@ -367,13 +372,14 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
         }
 
         private class CompletionListener extends Thread {
-            private boolean running = false;
+            private final AtomicBoolean running = new AtomicBoolean(false);
 
             public void start() {
-                if (running) {
+                // The token and "complete" responses are dispatched on pool threads and may
+                // race here; only the first caller may actually start the thread.
+                if (!running.compareAndSet(false, true)) {
                     return;
                 }
-                running = true;
                 super.start();
             }
 


### PR DESCRIPTION
Fixes #105.

## Problem

`AsyncRemoteSecureConnectorInfoManagerTest.testSerialBatchWithError` fails intermittently in CI with `IllegalThreadStateException` thrown from `BatchApiOpImpl$InternalRequest$CompletionListener.start()`.

`CompletionListener.start()` guarded `Thread.start()` with a plain, unsynchronized `boolean`. The listener is started from two branches of `handleOperationResponseMessages` — the batch-token branch and the "complete" branch — and operation responses are dispatched on a thread pool, so when the token and complete messages arrive close together, two pool threads can both observe `running == false` and both call `super.start()` (check-then-act race). The second `Thread.start()` throws, the exception propagates out of the message-processing task, and the batch result is lost.

## Fix

- Guard the start with an `AtomicBoolean` CAS — only the first caller may actually start the thread.
- Make `returnToken` `volatile` and publish it fully populated (build in a local, assign last): the `CompletionListener` thread spins on `returnToken == null`, and when it lost the `start()` race there was no happens-before edge, so it could observe a stale `null` or a partially built token.

## Testing

`AsyncRemoteSecureConnectorInfoManagerTest` (connector-server-grizzly, includes `testSerialBatchWithError`) run 4 times locally: `Tests run: 14, Failures: 0, Errors: 0` each time.