### PR TITLE
Fix lost pre-handshake responses causing testAsynchronousBatch to hang

### DIFF
--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
@@ -402,8 +402,16 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
                     // Without failing the promise here the caller blocked on it would
                     // wait forever for a token message that will never arrive.
                     logger.ok("Batch CompletionListener timed out. Unable to return batch token.");
-                    getExceptionHandler().handleException(new ConnectorException(
-                            "Batch operation failed to return a batch token"));
+                    if (!getPromise().isDone()) {
+                        getExceptionHandler().handleException(new ConnectorException(
+                                "Batch operation failed to return a batch token"));
+                        try {
+                            tryCancelRemote(getConnectionContext(), getRequestId());
+                        } catch (Exception e) {
+                            // The transport may already be down when the token was lost.
+                            logger.ok(e, "Failed to cancel remote batch operation.");
+                        }
+                    }
                 }
                 logger.ok("CompletionListener finished.");
             }

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
@@ -397,10 +397,14 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
                 if (returnToken != null) {
                     getResultHandler().handleResult(returnToken);
                     logger.ok("Token returned.");
+                    observer.onCompleted();
                 } else {
+                    // Without failing the promise here the caller blocked on it would
+                    // wait forever for a token message that will never arrive.
                     logger.ok("Batch CompletionListener timed out. Unable to return batch token.");
+                    getExceptionHandler().handleException(new ConnectorException(
+                            "Batch operation failed to return a batch token"));
                 }
-                observer.onCompleted();
                 logger.ok("CompletionListener finished.");
             }
         }

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/client/ClientRemoteConnectorInfoManager.java
@@ -533,7 +533,9 @@ public class ClientRemoteConnectorInfoManager extends
         protected final Queue<OperationMessageListener> listeners =
                 new ConcurrentLinkedQueue<OperationMessageListener>();
 
-        private RemoteOperationContext context = null;
+        // Written on the handshake-processing pool thread, read by other message
+        // threads via getRemoteConnectionContext()/isHandHooked().
+        private volatile RemoteOperationContext context = null;
 
         private final WebSocketConnectionHolder adapter = new WebSocketConnectionHolder() {
 

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 package org.forgerock.openicf.framework.remote;
 
@@ -20,6 +21,7 @@ import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import org.forgerock.openicf.common.protobuf.CommonObjectMessages;
 import org.forgerock.openicf.common.protobuf.OperationMessages;
@@ -141,6 +143,9 @@ public class OpenICFServerAdapter implements OperationMessageListener {
             if (logger.isOk()) {
                 logger.ok("{0} onMessage({1})", loggerName(), message.toString());
             }
+            if (!isHandshakeMessage(message)) {
+                awaitHandshake(socket, message.getMessageId());
+            }
             if (message.hasRequest()) {
                 if (message.getRequest().hasHandshakeMessage()) {
                     if (isClient()) {
@@ -197,6 +202,37 @@ public class OpenICFServerAdapter implements OperationMessageListener {
             logger.warn(e, "{0} failed parse message", loggerName());
         } catch (Throwable t) {
             logger.info(t, "{0} Unhandled exception", loggerName());
+        }
+    }
+
+    private static boolean isHandshakeMessage(final RemoteMessage message) {
+        return (message.hasRequest() && message.getRequest().hasHandshakeMessage())
+                || (message.hasResponse() && message.getResponse().hasHandshakeMessage());
+    }
+
+    /**
+     * Messages are processed on a thread pool, so a message received on a
+     * freshly opened connection can overtake the handshake that arrived just
+     * before it and would be dropped by the pre-handshake branches below. The
+     * handshake is being processed concurrently, so briefly wait for it
+     * instead of discarding the message.
+     */
+    private void awaitHandshake(final WebSocketConnectionHolder socket, long messageId) {
+        if (socket.isHandHooked()) {
+            return;
+        }
+        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        while (!socket.isHandHooked() && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+        if (!socket.isHandHooked()) {
+            logger.info("{0} handshake still pending after wait, message('{1}') via socket:{2} ",
+                    loggerName(), messageId, socket.hashCode());
         }
     }
 

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
@@ -21,7 +21,6 @@ import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 
 import org.forgerock.openicf.common.protobuf.CommonObjectMessages;
 import org.forgerock.openicf.common.protobuf.OperationMessages;
@@ -143,7 +142,7 @@ public class OpenICFServerAdapter implements OperationMessageListener {
             if (logger.isOk()) {
                 logger.ok("{0} onMessage({1})", loggerName(), message.toString());
             }
-            if (!isHandshakeMessage(message)) {
+            if (!isHandshakeMessage(message) && !isErrorResponse(message)) {
                 awaitHandshake(socket, message.getMessageId());
             }
             if (message.hasRequest()) {
@@ -211,17 +210,27 @@ public class OpenICFServerAdapter implements OperationMessageListener {
     }
 
     /**
+     * Error responses are handled before the isHandHooked() guards below, so
+     * they never need to wait for the handshake.
+     */
+    private static boolean isErrorResponse(final RemoteMessage message) {
+        return message.hasResponse() && message.getResponse().hasError();
+    }
+
+    /**
      * Messages are processed on a thread pool, so a message received on a
      * freshly opened connection can overtake the handshake that arrived just
      * before it and would be dropped by the pre-handshake branches below. The
-     * handshake is being processed concurrently, so briefly wait for it
-     * instead of discarding the message.
+     * handshake is being processed concurrently and normally lands within
+     * milliseconds, so briefly wait for it instead of discarding the message.
      */
+    private static final long HANDSHAKE_WAIT_MS = 500;
+
     private void awaitHandshake(final WebSocketConnectionHolder socket, long messageId) {
         if (socket.isHandHooked()) {
             return;
         }
-        final long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        final long deadline = System.currentTimeMillis() + HANDSHAKE_WAIT_MS;
         while (!socket.isHandHooked() && System.currentTimeMillis() < deadline) {
             try {
                 Thread.sleep(10);
@@ -231,7 +240,7 @@ public class OpenICFServerAdapter implements OperationMessageListener {
             }
         }
         if (!socket.isHandHooked()) {
-            logger.info("{0} handshake still pending after wait, message('{1}') via socket:{2} ",
+            logger.warn("{0} handshake still pending after wait, message('{1}') via socket:{2} ",
                     loggerName(), messageId, socket.hashCode());
         }
     }

--- a/OpenICF-java-framework/connector-framework-server/src/test/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImplTest.java
+++ b/OpenICF-java-framework/connector-framework-server/src/test/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImplTest.java
@@ -1,0 +1,172 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openicf.framework.async.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.forgerock.openicf.common.protobuf.OperationMessages.BatchOpResult;
+import org.forgerock.openicf.common.protobuf.OperationMessages.OperationResponse;
+import org.forgerock.openicf.common.protobuf.RPCMessages.HandshakeMessage;
+import org.forgerock.openicf.common.rpc.RemoteRequest;
+import org.forgerock.openicf.common.rpc.RemoteRequestFactory;
+import org.forgerock.openicf.common.rpc.RequestDistributor;
+import org.forgerock.openicf.framework.remote.rpc.RemoteOperationContext;
+import org.forgerock.openicf.framework.remote.rpc.WebSocketConnectionGroup;
+import org.forgerock.openicf.framework.remote.rpc.WebSocketConnectionHolder;
+import org.forgerock.util.Function;
+import org.identityconnectors.framework.api.ConnectorKey;
+import org.identityconnectors.framework.api.Observer;
+import org.identityconnectors.framework.api.operations.APIOperation;
+import org.identityconnectors.framework.api.operations.batch.BatchTask;
+import org.identityconnectors.framework.api.operations.batch.DeleteBatchTask;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.objects.BatchResult;
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
+import org.identityconnectors.framework.common.objects.Uid;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * Tests that a batch operation whose batch-token response is never delivered
+ * fails the caller with a {@link ConnectorException} when the
+ * CompletionListener times out, instead of leaving the caller blocked forever.
+ */
+public class BatchApiOpImplTest {
+
+    private static final ConnectorKey CONNECTOR_KEY =
+            new ConnectorKey("testbundle", "1.0", "test.Connector");
+
+    private static class RecordingObserver implements Observer<BatchResult> {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        public void onCompleted() {
+            completed.set(true);
+        }
+
+        public void onError(Throwable e) {
+            error.set(e);
+        }
+
+        public void onNext(BatchResult batchResult) {
+        }
+    }
+
+    private static final WebSocketConnectionHolder FAKE_SOCKET = new WebSocketConnectionHolder() {
+
+        protected void handshake(HandshakeMessage message) {
+        }
+
+        protected void tryClose() {
+        }
+
+        public boolean isOperational() {
+            return true;
+        }
+
+        public RemoteOperationContext getRemoteConnectionContext() {
+            return null;
+        }
+
+        public Future<?> sendBytes(byte[] data) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        public Future<?> sendString(String data) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        public void sendPing(byte[] applicationData) throws Exception {
+        }
+
+        public void sendPong(byte[] applicationData) throws Exception {
+        }
+    };
+
+    /**
+     * Submits the request over the fake socket and immediately delivers a
+     * "complete" BatchOpResult carrying no batch token, simulating a lost
+     * token response.
+     */
+    private static class NoTokenRequestDistributor
+            implements
+            RequestDistributor<WebSocketConnectionGroup, WebSocketConnectionHolder, RemoteOperationContext> {
+
+        public <R extends RemoteRequest<V, E, WebSocketConnectionGroup, WebSocketConnectionHolder, RemoteOperationContext>, V, E extends Exception> R trySubmitRequest(
+                RemoteRequestFactory<R, V, E, WebSocketConnectionGroup, WebSocketConnectionHolder, RemoteOperationContext> requestFactory) {
+            R request =
+                    requestFactory.createRemoteRequest(null, 1L,
+                            new RemoteRequestFactory.CompletionCallback<V, E, WebSocketConnectionGroup, WebSocketConnectionHolder, RemoteOperationContext>() {
+                                public void complete(
+                                        RemoteRequest<V, E, WebSocketConnectionGroup, WebSocketConnectionHolder, RemoteOperationContext> request) {
+                                }
+                            });
+            try {
+                request.getSendFunction().apply(FAKE_SOCKET);
+            } catch (Exception e) {
+                throw ConnectorException.wrap(e);
+            }
+            request.handleIncomingMessage(FAKE_SOCKET, OperationResponse.newBuilder()
+                    .setBatchOpResult(BatchOpResult.newBuilder().setComplete(true)).build());
+            return request;
+        }
+
+        public boolean isOperational() {
+            return true;
+        }
+    }
+
+    @Test(timeOut = 30000)
+    public void testExecuteBatchFailsWhenNoTokenArrives() {
+        BatchApiOpImpl operation =
+                new BatchApiOpImpl(new NoTokenRequestDistributor(), CONNECTOR_KEY,
+                        new Function<RemoteOperationContext, ByteString, RuntimeException>() {
+                            public ByteString apply(RemoteOperationContext context) {
+                                return ByteString.EMPTY;
+                            }
+                        }, APIOperation.NO_TIMEOUT);
+
+        List<BatchTask> tasks =
+                Collections.<BatchTask> singletonList(new DeleteBatchTask(ObjectClass.ACCOUNT,
+                        new Uid("1"), new OperationOptionsBuilder().build()));
+        RecordingObserver observer = new RecordingObserver();
+
+        long start = System.currentTimeMillis();
+        try {
+            operation.executeBatch(tasks, observer, new OperationOptionsBuilder().build());
+            Assert.fail("executeBatch must fail when no batch token arrives");
+        } catch (ConnectorException expected) {
+            Assert.assertTrue(expected.getMessage().contains("batch token"),
+                    "Unexpected failure: " + expected.getMessage());
+        }
+        long elapsed = System.currentTimeMillis() - start;
+
+        // CompletionListener gives up ~5s after the request was created.
+        Assert.assertTrue(elapsed < 20000, "Failure took too long: " + elapsed + "ms");
+        Assert.assertNotNull(observer.error.get(), "observer.onError must be called");
+        Assert.assertTrue(observer.error.get() instanceof ConnectorException);
+        Assert.assertFalse(observer.completed.get(),
+                "observer.onCompleted must not be called without a token");
+    }
+}

--- a/OpenICF-java-framework/connector-server-grizzly/src/main/java/org/forgerock/openicf/framework/server/grizzly/OpenICFWebSocketApplication.java
+++ b/OpenICF-java-framework/connector-server-grizzly/src/main/java/org/forgerock/openicf/framework/server/grizzly/OpenICFWebSocketApplication.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.server.grizzly;
@@ -169,7 +171,9 @@ public class OpenICFWebSocketApplication extends WebSocketApplication implements
                 new ConcurrentLinkedQueue<OperationMessageListener>();
 
         private final ConnectionPrincipal<?> connectionPrincipal;
-        private RemoteOperationContext context = null;
+        // Written on the handshake-processing pool thread, read by other message
+        // threads via getRemoteConnectionContext()/isHandHooked().
+        private volatile RemoteOperationContext context = null;
 
         private final WebSocketConnectionHolder adapter = new WebSocketConnectionHolder() {
 

--- a/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/SinglePrincipal.java
+++ b/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/SinglePrincipal.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2025 3A Systems LLC.
+ * Portions copyright 2025-2026 3A Systems LLC.
  */
 
 
@@ -145,7 +145,9 @@ public class SinglePrincipal extends ConnectionPrincipal<SinglePrincipal> implem
     private static final Logger logger = Log.getLogger(SinglePrincipal.class);
     private boolean hasCloseBeenCalled = false;
 
-    private RemoteOperationContext context = null;
+    // Written on the handshake-processing pool thread, read by other message
+    // threads via getRemoteConnectionContext()/isHandHooked().
+    private volatile RemoteOperationContext context = null;
 
     private final WebSocketConnectionHolder adapter = new WebSocketConnectionHolder() {
 


### PR DESCRIPTION
Fixes #107

`AsyncRemoteSecureConnectorInfoManagerTest.testAsynchronousBatch` intermittently fails in CI after exactly 540 s with `ConnectorException: Operation finished on remote server with unknown result` ([example run](https://github.com/OpenIdentityPlatform/OpenICF/actions/runs/29724340797/job/88293965805)). This still reproduced after #105, which fixed a different race.

### Root cause

1. `OpenICFServerAdapter.onMessage` dispatches every WebSocket message to a cached thread pool, so two messages delivered in order on the same socket can be processed out of order. On a freshly opened socket the batch-token operation response overtook the handshake response, and the pre-handshake branch of `handleResponseMessage` silently discarded it (`Client received response('2') before handshake via socket:...`).
2. With the token lost, `BatchApiOpImpl$InternalRequest.CompletionListener` timed out with `returnToken == null` and exited without completing the promise, leaving the caller blocked forever in `promise.getOrThrowUninterruptibly()` inside `executeBatch()`.
3. The connection group checker (1 min + every 4 min, 3 `inconsistent()` strikes) finally failed the operation at the 9-minute mark — hence exactly 540 s.

### Fix

- **`OpenICFServerAdapter`**: before dispatching a non-handshake message on a socket that is not yet handhooked, briefly wait (poll up to 10 s) for the concurrently-processing handshake to land instead of discarding the message. In the race this resolves in tens of milliseconds; if no handshake ever arrives, behavior falls through to the existing drop-with-error path.
- **`BatchApiOpImpl`**: when `CompletionListener` times out with no batch token, fail the promise with a `ConnectorException` instead of returning silently, so any future message loss surfaces as an error in ~5 s instead of a 9-minute hang. `observer.onCompleted()` is now only called when a token was actually delivered; the failure path signals `observer.onError` via the existing `thenOnException` chain.

### Testing

- `AsyncRemoteSecureConnectorInfoManagerTest` (the flaky class): 14/14 pass
- Full `connector-server-grizzly` suite: 32/32 pass
- Full `connector-framework-server` suite: 24/24 pass

The race itself is timing-dependent (not reproducible locally on demand), so the real proof will be Windows CI over time.
