### PR TITLE
[#111] Give embedded OpenDJ 30 s to start and stop in LDAP connector tests

### DIFF
--- a/OpenICF-ldap-connector/src/test/java/org/identityconnectors/ldap/LdapConnectorTestBase.java
+++ b/OpenICF-ldap-connector/src/test/java/org/identityconnectors/ldap/LdapConnectorTestBase.java
@@ -262,7 +262,7 @@ public abstract class LdapConnectorTestBase {
      */
     private static void waitUntilListening() throws IOException {
         final int WAIT = 200; // ms
-        final int ITERATIONS = 50;
+        final int ITERATIONS = 150; // 30 s: a loaded CI runner can be very slow (#111)
         for (int i = 1; !isListening(PORT) || !isListening(SSL_PORT); i++) {
             if (i >= ITERATIONS) {
                 throw new IOException("OpenDJ is not listening on ports " + PORT + " and " + SSL_PORT
@@ -292,7 +292,7 @@ public abstract class LdapConnectorTestBase {
      */
     private static boolean waitUntilStopped() {
         final int WAIT = 200; // ms
-        final int ITERATIONS = 25;
+        final int ITERATIONS = 150; // 30 s: a loaded CI runner can be very slow (#111)
         for (int i = 1; EmbeddedUtils.isRunning() || isAnyPortStillBound(); i++) {
             if (i >= ITERATIONS) {
                 return false;


### PR DESCRIPTION
Fixes #111.

### Problem

`LdapConnectorTestBase.waitUntilStopped()` gives the embedded OpenDJ only 25 × 200 ms = 5 s to shut down. On a loaded CI runner the stop after applying `test-config.ldif` can exceed that, so `startAndApply` throws from `before()`. A failure in a configuration method is not forgiven by surefire reruns (Run 1: FAIL, Run 2–3: PASS in the observed run), so the module fails and cascade-skips the remaining tests (309 skipped in https://github.com/OpenIdentityPlatform/OpenICF/actions/runs/29743183432/job/88354582201).

### Change

- `waitUntilStopped()`: shutdown budget 5 s → 30 s (`ITERATIONS` 25 → 150). Covers both call sites — `startAndApply()` and `stopServer()`.
- `waitUntilListening()`: startup budget 10 s → 30 s (`ITERATIONS` 50 → 150) — same failure class on a slow runner, aligned while at it.

Both loops exit as soon as the server is actually up/down, so the successful case is unaffected; the change only widens the margin on slow runners.

### Testing

`mvn test -Dtest=LdapDeleteTests` (the class that failed in CI) against the embedded OpenDJ: 3 tests, 0 failures, 0 errors.