### PR TITLE
[#112] Deliver CancelOpRequest arriving before the operation registers

### DIFF
--- a/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
@@ -47,6 +47,13 @@ public abstract class LocalRequest<V, E extends Exception, G extends RemoteConne
 
     private final AtomicBoolean cancelled = new AtomicBoolean(Boolean.FALSE);
 
+    /**
+     * Creates the request without registering it. Historically the
+     * constructor registered {@code this} in the
+     * {@link RemoteConnectionGroup}; subclasses relying on that must now call
+     * {@link #register()} after construction, or the request will never
+     * receive responses or cancel messages.
+     */
     protected LocalRequest(final long requestId, final H socket) {
         this.requestId = requestId;
         remoteConnectionContext = socket.getRemoteConnectionContext();
@@ -93,6 +100,15 @@ public abstract class LocalRequest<V, E extends Exception, G extends RemoteConne
 
     public P getRemoteConnectionContext() {
         return remoteConnectionContext;
+    }
+
+    /**
+     * Returns {@code true} once a {@link #cancel()} has been delivered to
+     * this request, whether directly or as a pending cancel applied during
+     * {@link #register()}.
+     */
+    public final boolean isCancelled() {
+        return cancelled.get();
     }
 
     public final boolean cancel() {

--- a/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/LocalRequest.java
@@ -26,6 +26,8 @@
 
 package org.forgerock.openicf.common.rpc;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.forgerock.util.promise.ExceptionHandler;
 import org.forgerock.util.promise.ResultHandler;
 
@@ -43,10 +45,27 @@ public abstract class LocalRequest<V, E extends Exception, G extends RemoteConne
 
     private final P remoteConnectionContext;
 
+    private final AtomicBoolean cancelled = new AtomicBoolean(Boolean.FALSE);
+
     protected LocalRequest(final long requestId, final H socket) {
         this.requestId = requestId;
         remoteConnectionContext = socket.getRemoteConnectionContext();
-        remoteConnectionContext.getRemoteConnectionGroup().receiveRequest(this);
+    }
+
+    /**
+     * Registers this request in the
+     * {@link RemoteConnectionGroup} so responses and cancel messages can be
+     * dispatched to it. Must be called once the request is fully constructed
+     * and before it is executed: registration publishes this instance to
+     * other threads, and a registration racing with the constructor would let
+     * a concurrent cancel observe a partially initialized subclass.
+     *
+     * @return {@code true} when the request is registered and live,
+     *         {@code false} when a cancel for this request id was already
+     *         received - the request is cancelled and must not be executed.
+     */
+    public final boolean register() {
+        return null != remoteConnectionContext.getRemoteConnectionGroup().receiveRequest(this);
     }
 
     /**
@@ -78,7 +97,12 @@ public abstract class LocalRequest<V, E extends Exception, G extends RemoteConne
 
     public final boolean cancel() {
         remoteConnectionContext.getRemoteConnectionGroup().removeRequest(getRequestId());
-        return tryCancel();
+        // A cancel may be delivered twice when a direct cancel races with a
+        // pending cancel applied during register() - deliver tryCancel() once.
+        if (cancelled.compareAndSet(Boolean.FALSE, Boolean.TRUE)) {
+            return tryCancel();
+        }
+        return false;
     }
 
     public final void handleResult(final V result) {

--- a/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
@@ -27,6 +27,9 @@
 package org.forgerock.openicf.common.rpc;
 
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -59,6 +62,19 @@ public abstract class RemoteConnectionGroup<G extends RemoteConnectionGroup<G, H
 
     protected final ConcurrentNavigableMap<Long, LocalRequest<?, ?, G, H, P>> localRequests =
             new ConcurrentSkipListMap<Long, LocalRequest<?, ?, G, H, P>>();
+
+    /**
+     * Cancel messages that arrived before the addressed operation registered
+     * itself in {@link #localRequests} are parked here (request id to expiry
+     * timestamp) and applied when {@link #receiveRequest} registers the
+     * request. Request ids are never reused within a group, so a parked
+     * cancel can only ever match the operation it was sent for; entries whose
+     * operation never arrives are dropped after {@link #PENDING_CANCEL_TTL_MS}.
+     */
+    private final ConcurrentMap<Long, Long> pendingCancels =
+            new ConcurrentHashMap<Long, Long>();
+
+    private static final long PENDING_CANCEL_TTL_MS = 60L * 1000L;
 
     protected final CopyOnWriteArrayList<Pair<String, H>> webSockets =
             new CopyOnWriteArrayList<Pair<String, H>>();
@@ -192,13 +208,29 @@ public abstract class RemoteConnectionGroup<G extends RemoteConnectionGroup<G, H
         return remoteRequest;
     }
 
+    /**
+     * Registers the given request so responses and cancel messages can be
+     * dispatched to it.
+     *
+     * @return the registered request, or {@code null} when a cancel for its
+     *         request id arrived before registration - the request is
+     *         cancelled and must not be executed.
+     */
     public <V, E extends Exception, R extends LocalRequest<V, E, G, H, P>> R receiveRequest(
             final R localRequest) {
+        purgeExpiredPendingCancels();
         LocalRequest<?, ?, G, H, P> tmp =
                 localRequests.putIfAbsent(localRequest.getRequestId(), localRequest);
         if (null != tmp && !tmp.equals(localRequest)) {
             throw new IllegalStateException("Request has been registered with id: "
                     + localRequest.getRequestId());
+        }
+        // Registration and receiveRequestCancel write the two maps in
+        // opposite order, so whichever call runs second is guaranteed to see
+        // the other's entry and deliver the cancel.
+        if (null != pendingCancels.remove(localRequest.getRequestId())) {
+            localRequest.cancel();
+            return null;
         }
         return localRequest;
     }
@@ -216,11 +248,29 @@ public abstract class RemoteConnectionGroup<G extends RemoteConnectionGroup<G, H
     }
 
     public LocalRequest<?, ?, G, H, P> receiveRequestCancel(long messageId) {
+        purgeExpiredPendingCancels();
+        // Park first, then look up: the operation may be racing through
+        // registration on another thread, and this order guarantees that at
+        // least one side observes the other (see receiveRequest).
+        pendingCancels.put(messageId, System.currentTimeMillis() + PENDING_CANCEL_TTL_MS);
         LocalRequest<?, ?, G, H, P> tmp = localRequests.remove(messageId);
         if (null != tmp) {
+            pendingCancels.remove(messageId);
             tmp.cancel();
         }
         return tmp;
+    }
+
+    private void purgeExpiredPendingCancels() {
+        if (pendingCancels.isEmpty()) {
+            return;
+        }
+        final long now = System.currentTimeMillis();
+        for (Map.Entry<Long, Long> entry : pendingCancels.entrySet()) {
+            if (entry.getValue() < now) {
+                pendingCancels.remove(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     // -- Pair of methods to Cancel pending Request End --

--- a/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/main/java/org/forgerock/openicf/common/rpc/RemoteConnectionGroup.java
@@ -70,6 +70,10 @@ public abstract class RemoteConnectionGroup<G extends RemoteConnectionGroup<G, H
      * request. Request ids are never reused within a group, so a parked
      * cancel can only ever match the operation it was sent for; entries whose
      * operation never arrives are dropped after {@link #PENDING_CANCEL_TTL_MS}.
+     * The park in {@link #receiveRequestCancel} is unconditional, so a cancel
+     * that loses the race with completion (the operation already produced its
+     * result and unregistered) also leaves an entry behind for the full TTL;
+     * such entries are harmless and are removed by the next purge.
      */
     private final ConcurrentMap<Long, Long> pendingCancels =
             new ConcurrentHashMap<Long, Long>();
@@ -227,9 +231,19 @@ public abstract class RemoteConnectionGroup<G extends RemoteConnectionGroup<G, H
         }
         // Registration and receiveRequestCancel write the two maps in
         // opposite order, so whichever call runs second is guaranteed to see
-        // the other's entry and deliver the cancel.
+        // the other's entry and deliver the cancel. The verdict must come
+        // from the request's own state rather than from winning the park
+        // removal: receiveRequestCancel may find the request in localRequests
+        // right after the putIfAbsent above, consume its own park and cancel
+        // the request directly - this thread then observes no parked entry.
         if (null != pendingCancels.remove(localRequest.getRequestId())) {
             localRequest.cancel();
+        }
+        if (localRequest.isCancelled()) {
+            // cancel() removes the registration, but only when the cancelling
+            // side found it - make sure a request reported dead is never left
+            // registered.
+            localRequests.remove(localRequest.getRequestId(), localRequest);
             return null;
         }
         return localRequest;

--- a/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/LocalRequestRegistrationTest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/LocalRequestRegistrationTest.java
@@ -1,0 +1,136 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 3A Systems, LLC.
+ */
+package org.forgerock.openicf.common.rpc;
+
+import java.util.concurrent.Future;
+
+import org.forgerock.openicf.common.rpc.impl.TestConnectionContext;
+import org.forgerock.openicf.common.rpc.impl.TestConnectionGroup;
+import org.forgerock.openicf.common.rpc.impl.TestLocalRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the explicit {@link LocalRequest#register()} step and the handling of
+ * a {@code CancelOpRequest} that is processed before the addressed operation
+ * has registered itself (OpenIdentityPlatform/OpenICF#112).
+ */
+public class LocalRequestRegistrationTest<H extends RemoteConnectionHolder<TestConnectionGroup<H>, H, TestConnectionContext<H>>> {
+
+    /**
+     * Minimal connection holder: the tests never transmit anything, they only
+     * need {@link #getRemoteConnectionContext()} to reach the group.
+     */
+    private class StubConnectionHolder implements
+            RemoteConnectionHolder<TestConnectionGroup<H>, H, TestConnectionContext<H>> {
+
+        private final TestConnectionGroup<H> group;
+
+        private StubConnectionHolder(TestConnectionGroup<H> group) {
+            this.group = group;
+        }
+
+        public TestConnectionContext<H> getRemoteConnectionContext() {
+            return group.getRemoteConnectionContext();
+        }
+
+        public Future<?> sendBytes(byte[] data) {
+            throw new UnsupportedOperationException();
+        }
+
+        public Future<?> sendString(String data) {
+            throw new UnsupportedOperationException();
+        }
+
+        public void sendPing(byte[] applicationData) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        public void sendPong(byte[] applicationData) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        public void close() {
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private H newSocket(TestConnectionGroup<H> group) {
+        return (H) new StubConnectionHolder(group);
+    }
+
+    @Test
+    public void testConstructorDoesNotRegister() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+        new TestLocalRequest<H>(1L, newSocket(group));
+        Assert.assertTrue(group.getLocalRequests().isEmpty());
+    }
+
+    @Test
+    public void testRegisterThenCancel() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+        TestLocalRequest<H> request = new TestLocalRequest<H>(1L, newSocket(group));
+
+        Assert.assertTrue(request.register());
+        Assert.assertTrue(group.getLocalRequests().contains(1L));
+
+        Assert.assertSame(group.receiveRequestCancel(1L), request);
+        Assert.assertTrue(request.isCancelled());
+        Assert.assertTrue(group.getLocalRequests().isEmpty());
+    }
+
+    @Test
+    public void testCancelBeforeRegistrationIsParked() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+
+        // The cancel is processed before the operation registered itself.
+        Assert.assertNull(group.receiveRequestCancel(1L));
+
+        TestLocalRequest<H> request = new TestLocalRequest<H>(1L, newSocket(group));
+        Assert.assertFalse(request.register());
+        Assert.assertTrue(request.isCancelled());
+        Assert.assertTrue(group.getLocalRequests().isEmpty());
+    }
+
+    @Test
+    public void testParkedCancelDoesNotAffectOtherRequests() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+
+        Assert.assertNull(group.receiveRequestCancel(1L));
+
+        TestLocalRequest<H> other = new TestLocalRequest<H>(2L, newSocket(group));
+        Assert.assertTrue(other.register());
+        Assert.assertFalse(other.isCancelled());
+        Assert.assertTrue(group.getLocalRequests().contains(2L));
+    }
+
+    @Test
+    public void testCancelIsDeliveredOnce() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+        final int[] cancelCount = new int[1];
+        TestLocalRequest<H> request = new TestLocalRequest<H>(1L, newSocket(group)) {
+            public boolean tryCancel() {
+                cancelCount[0]++;
+                return super.tryCancel();
+            }
+        };
+
+        Assert.assertTrue(request.register());
+        Assert.assertTrue(request.cancel());
+        Assert.assertFalse(request.cancel());
+        Assert.assertEquals(cancelCount[0], 1);
+    }
+}

--- a/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/LocalRequestRegistrationTest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/LocalRequestRegistrationTest.java
@@ -15,7 +15,12 @@
  */
 package org.forgerock.openicf.common.rpc;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.forgerock.openicf.common.rpc.impl.TestConnectionContext;
 import org.forgerock.openicf.common.rpc.impl.TestConnectionGroup;
@@ -132,5 +137,75 @@ public class LocalRequestRegistrationTest<H extends RemoteConnectionHolder<TestC
         Assert.assertTrue(request.cancel());
         Assert.assertFalse(request.cancel());
         Assert.assertEquals(cancelCount[0], 1);
+    }
+
+    /**
+     * Replays the interleaving where the whole {@code receiveRequestCancel}
+     * runs between the registration's {@code putIfAbsent} and its pending
+     * cancel check: the re-registration below stands in for the registering
+     * thread resuming after the cancel was delivered directly. The verdict
+     * must come from the request's own cancelled state, so register() must
+     * still report the request dead.
+     */
+    @Test
+    public void testRegisterObservesDirectlyDeliveredCancel() throws Exception {
+        TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+        TestLocalRequest<H> request = new TestLocalRequest<H>(1L, newSocket(group));
+
+        Assert.assertTrue(request.register());
+        Assert.assertSame(group.receiveRequestCancel(1L), request);
+
+        Assert.assertFalse(request.register());
+        Assert.assertTrue(request.isCancelled());
+        Assert.assertTrue(group.getLocalRequests().isEmpty());
+    }
+
+    /**
+     * Races {@link LocalRequest#register()} against
+     * {@link TestConnectionGroup#receiveRequestCancel(long)}. Whatever the
+     * interleaving, the cancel must be delivered exactly once and the request
+     * must end up unregistered.
+     */
+    @Test
+    public void testConcurrentRegisterAndCancel() throws Exception {
+        final TestConnectionGroup<H> group = new TestConnectionGroup<H>("test");
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (long requestId = 1; requestId <= 1000; requestId++) {
+                final long id = requestId;
+                final AtomicInteger cancelCount = new AtomicInteger(0);
+                final TestLocalRequest<H> request =
+                        new TestLocalRequest<H>(id, newSocket(group)) {
+                            public boolean tryCancel() {
+                                cancelCount.incrementAndGet();
+                                return super.tryCancel();
+                            }
+                        };
+                final CyclicBarrier barrier = new CyclicBarrier(2);
+                Future<Boolean> registered = executor.submit(new Callable<Boolean>() {
+                    public Boolean call() throws Exception {
+                        barrier.await();
+                        return request.register();
+                    }
+                });
+                Future<Object> cancelled = executor.submit(new Callable<Object>() {
+                    public Object call() throws Exception {
+                        barrier.await();
+                        return group.receiveRequestCancel(id);
+                    }
+                });
+                cancelled.get();
+                Boolean live = registered.get();
+
+                Assert.assertTrue(request.isCancelled(), "round " + id
+                        + ": cancel was lost");
+                Assert.assertEquals(cancelCount.get(), 1, "round " + id
+                        + ": tryCancel() delivered more than once");
+                Assert.assertFalse(group.getLocalRequests().contains(id), "round " + id
+                        + ": cancelled request left registered (register() == " + live + ")");
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/RequestDistributorTest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/RequestDistributorTest.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.common.rpc;
@@ -73,7 +75,9 @@ public class RequestDistributorTest<H extends RemoteConnectionHolder<TestConnect
                 if (obj.request >= 0) {
                     TestLocalRequest<H> request = new TestLocalRequest<H>(obj.messageId, socket);
                     try {
-                        getConnectionGroup().receiveRequest(request).execute(obj.request);
+                        if (request.register()) {
+                            request.execute(obj.request);
+                        }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         // request.handleException(e);

--- a/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/impl/TestLocalRequest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/impl/TestLocalRequest.java
@@ -113,10 +113,6 @@ public class TestLocalRequest<H extends RemoteConnectionHolder<TestConnectionGro
         return true;
     }
 
-    public boolean isCancelled() {
-        return cancelled;
-    }
-
     public void execute(int operation) throws InterruptedException {
         switch (operation) {
         case 0: {

--- a/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/impl/TestLocalRequest.java
+++ b/OpenICF-java-framework/connector-framework-rpc/src/test/java/org/forgerock/openicf/common/rpc/impl/TestLocalRequest.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.common.rpc.impl;
@@ -109,6 +111,10 @@ public class TestLocalRequest<H extends RemoteConnectionHolder<TestConnectionGro
     public boolean tryCancel() {
         cancelled = true;
         return true;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
     }
 
     public void execute(int operation) throws InterruptedException {

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/BatchApiOpImpl.java
@@ -465,6 +465,7 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
             AbstractLocalOperationProcessor<BatchOpResult, BatchOpRequest> {
 
         private Subscription subscription = null;
+        private boolean cancelled = false;
         private final AtomicBoolean commandChannelComplete = new AtomicBoolean(false);
         private final AtomicInteger resultChannelComplete = new AtomicInteger(0);
 
@@ -553,6 +554,7 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
                 }
             };
 
+            Subscription batchSubscription = null;
 
             if (!requestMessage.getQuery()) {
                 final List<BatchTask> tasks = new ArrayList<BatchTask>();
@@ -588,7 +590,7 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
                 }
 
                 try {
-                    subscription = connectorFacade.executeBatch(tasks, observer, options);
+                    batchSubscription = connectorFacade.executeBatch(tasks, observer, options);
                 } catch (Throwable t) {
                     tryHandleError(new ConnectorException(t));
                     return BatchOpResult.newBuilder().build();
@@ -599,16 +601,20 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
                     for (int i = 0; i < requestMessage.getBatchTokenCount(); i++) {
                         queryToken.addToken(requestMessage.getBatchToken(i));
                     }
-                    subscription = connectorFacade.queryBatch(queryToken, observer, options);
+                    batchSubscription = connectorFacade.queryBatch(queryToken, observer, options);
                 } catch (Throwable t) {
                     tryHandleError(new ConnectorException(t));
                     return BatchOpResult.newBuilder().build();
                 }
             }
 
+            if (null != batchSubscription) {
+                attachSubscription(batchSubscription);
+            }
+
             BatchOpResult.Builder result = BatchOpResult.newBuilder();
-            if (subscription != null && subscription.getReturnValue() != null) {
-                BatchToken returnedToken = (BatchToken) subscription.getReturnValue();
+            if (batchSubscription != null && batchSubscription.getReturnValue() != null) {
+                BatchToken returnedToken = (BatchToken) batchSubscription.getReturnValue();
                 for (String token : returnedToken.getTokens()) {
                     result.addBatchToken(token);
                 }
@@ -623,8 +629,35 @@ public class BatchApiOpImpl extends AbstractAPIOperation implements BatchApiOp {
             return result.build();
         }
 
+        /**
+         * The subscription is created only after this request is registered,
+         * so a cancel can be delivered before the field is assigned; the
+         * hand-over happens under the lock so exactly one side closes the
+         * subscription.
+         */
+        private void attachSubscription(final Subscription result) {
+            final boolean closeNow;
+            synchronized (this) {
+                closeNow = cancelled;
+                if (!closeNow) {
+                    subscription = result;
+                }
+            }
+            if (closeNow) {
+                result.close();
+            }
+        }
+
         protected boolean tryCancel() {
-            subscription.close();
+            final Subscription current;
+            synchronized (this) {
+                cancelled = true;
+                current = subscription;
+                subscription = null;
+            }
+            if (null != current) {
+                current.close();
+            }
             return super.tryCancel();
         }
     }

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/ConnectorEventSubscriptionApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/ConnectorEventSubscriptionApiOpImpl.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.async.impl;
@@ -227,6 +229,7 @@ public class ConnectorEventSubscriptionApiOpImpl extends AbstractAPIOperation im
             extends
             AbstractLocalOperationProcessor<ConnectorEventSubscriptionOpResponse, ConnectorEventSubscriptionOpRequest> {
         private Subscription subscription = null;
+        private boolean cancelled = false;
 
         protected InternalLocalOperationProcessor(long requestId, WebSocketConnectionHolder socket,
                 ConnectorEventSubscriptionOpRequest message) {
@@ -265,7 +268,7 @@ public class ConnectorEventSubscriptionApiOpImpl extends AbstractAPIOperation im
                 operationOptions = MessagesUtil.deserializeLegacy(requestMessage.getOptions());
             }
 
-            subscription =
+            final Subscription result =
                     connectorFacade.subscribe(objectClass, token, new Observer<ConnectorObject>() {
 
                         public void onCompleted() {
@@ -294,11 +297,39 @@ public class ConnectorEventSubscriptionApiOpImpl extends AbstractAPIOperation im
 
                     }, operationOptions);
 
+            attachSubscription(result);
             return ConnectorEventSubscriptionOpResponse.getDefaultInstance();
         }
 
+        /**
+         * The subscription is created only after this request is registered,
+         * so a cancel can be delivered before the field is assigned; the
+         * hand-over happens under the lock so exactly one side closes the
+         * subscription.
+         */
+        private void attachSubscription(final Subscription result) {
+            final boolean closeNow;
+            synchronized (this) {
+                closeNow = cancelled;
+                if (!closeNow) {
+                    subscription = result;
+                }
+            }
+            if (closeNow) {
+                result.close();
+            }
+        }
+
         protected boolean tryCancel() {
-            subscription.close();
+            final Subscription current;
+            synchronized (this) {
+                cancelled = true;
+                current = subscription;
+                subscription = null;
+            }
+            if (null != current) {
+                current.close();
+            }
             return super.tryCancel();
         }
     }

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/SyncEventSubscriptionApiOpImpl.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/async/impl/SyncEventSubscriptionApiOpImpl.java
@@ -20,6 +20,8 @@
  * with the fields enclosed by brackets [] replaced by
  * your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
+ *
+ * Portions Copyrighted 2026 3A Systems, LLC
  */
 
 package org.forgerock.openicf.framework.async.impl;
@@ -219,6 +221,7 @@ public class SyncEventSubscriptionApiOpImpl extends AbstractAPIOperation impleme
             AbstractLocalOperationProcessor<SyncEventSubscriptionOpResponse, SyncEventSubscriptionOpRequest> {
 
         private Subscription subscription = null;
+        private boolean cancelled = false;
 
         protected InternalLocalOperationProcessor(long requestId, WebSocketConnectionHolder socket,
                 SyncEventSubscriptionOpRequest message) {
@@ -258,7 +261,7 @@ public class SyncEventSubscriptionApiOpImpl extends AbstractAPIOperation impleme
                 operationOptions = MessagesUtil.deserializeLegacy(requestMessage.getOptions());
             }
 
-            subscription = connectorFacade.subscribe(objectClass, token, new Observer<SyncDelta>() {
+            final Subscription result = connectorFacade.subscribe(objectClass, token, new Observer<SyncDelta>() {
 
                 public void onCompleted() {
                     handleResult(SyncEventSubscriptionOpResponse.newBuilder().setCompleted(
@@ -283,11 +286,39 @@ public class SyncEventSubscriptionApiOpImpl extends AbstractAPIOperation impleme
 
             }, operationOptions);
 
+            attachSubscription(result);
             return SyncEventSubscriptionOpResponse.getDefaultInstance();
         }
 
+        /**
+         * The subscription is created only after this request is registered,
+         * so a cancel can be delivered before the field is assigned; the
+         * hand-over happens under the lock so exactly one side closes the
+         * subscription.
+         */
+        private void attachSubscription(final Subscription result) {
+            final boolean closeNow;
+            synchronized (this) {
+                closeNow = cancelled;
+                if (!closeNow) {
+                    subscription = result;
+                }
+            }
+            if (closeNow) {
+                result.close();
+            }
+        }
+
         protected boolean tryCancel() {
-            subscription.close();
+            final Subscription current;
+            synchronized (this) {
+                cancelled = true;
+                current = subscription;
+                subscription = null;
+            }
+            if (null != current) {
+                current.close();
+            }
             return super.tryCancel();
         }
     }

--- a/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
+++ b/OpenICF-java-framework/connector-framework-server/src/main/java/org/forgerock/openicf/framework/remote/OpenICFServerAdapter.java
@@ -37,6 +37,7 @@ import org.forgerock.openicf.common.protobuf.RPCMessages.RPCResponse;
 import org.forgerock.openicf.common.protobuf.RPCMessages.RemoteMessage;
 import org.forgerock.openicf.framework.ConnectorFramework;
 import org.forgerock.openicf.framework.async.AsyncConnectorInfoManager;
+import org.forgerock.openicf.framework.async.impl.AbstractLocalOperationProcessor;
 import org.forgerock.openicf.framework.async.impl.AuthenticationAsyncApiOpImpl;
 import org.forgerock.openicf.framework.async.impl.BatchApiOpImpl;
 import org.forgerock.openicf.framework.async.impl.ConnectorEventSubscriptionApiOpImpl;
@@ -423,62 +424,70 @@ public class OpenICFServerAdapter implements OperationMessageListener {
 
                     ConnectorFacade connectorFacade = newInstance(socket, info, connectorFacadeKey);
 
+                    AbstractLocalOperationProcessor<?, ?> processor = null;
                     if (message.hasBatchOpRequest()) {
-                        BatchApiOpImpl.createProcessor(messageId, socket,
-                                message.getBatchOpRequest()).execute(connectorFacade);
+                        processor = BatchApiOpImpl.createProcessor(messageId, socket,
+                                message.getBatchOpRequest());
                     } else if (message.hasAuthenticateOpRequest()) {
-                        AuthenticationAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getAuthenticateOpRequest()).execute(connectorFacade);
+                        processor = AuthenticationAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getAuthenticateOpRequest());
                     } else if (message.hasCreateOpRequest()) {
-                        CreateAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getCreateOpRequest()).execute(connectorFacade);
+                        processor = CreateAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getCreateOpRequest());
                     } else if (message.hasConnectorEventSubscriptionOpRequest()) {
-                        ConnectorEventSubscriptionApiOpImpl.createProcessor(messageId, socket,
-                                message.getConnectorEventSubscriptionOpRequest()).execute(
-                                connectorFacade);
+                        processor = ConnectorEventSubscriptionApiOpImpl.createProcessor(messageId,
+                                socket, message.getConnectorEventSubscriptionOpRequest());
                     } else if (message.hasDeleteOpRequest()) {
-                        DeleteAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getDeleteOpRequest()).execute(connectorFacade);
+                        processor = DeleteAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getDeleteOpRequest());
                     } else if (message.hasGetOpRequest()) {
-                        GetAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getGetOpRequest()).execute(connectorFacade);
+                        processor = GetAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getGetOpRequest());
                     } else if (message.hasResolveUsernameOpRequest()) {
-                        ResolveUsernameAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getResolveUsernameOpRequest()).execute(connectorFacade);
+                        processor = ResolveUsernameAsyncApiOpImpl.createProcessor(messageId,
+                                socket, message.getResolveUsernameOpRequest());
                     } else if (message.hasSchemaOpRequest()) {
-                        SchemaAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getSchemaOpRequest()).execute(connectorFacade);
+                        processor = SchemaAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getSchemaOpRequest());
                     } else if (message.hasScriptOnConnectorOpRequest()) {
-                        ScriptOnConnectorAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getScriptOnConnectorOpRequest()).execute(connectorFacade);
+                        processor = ScriptOnConnectorAsyncApiOpImpl.createProcessor(messageId,
+                                socket, message.getScriptOnConnectorOpRequest());
                     } else if (message.hasScriptOnResourceOpRequest()) {
-                        ScriptOnResourceAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getScriptOnResourceOpRequest()).execute(connectorFacade);
+                        processor = ScriptOnResourceAsyncApiOpImpl.createProcessor(messageId,
+                                socket, message.getScriptOnResourceOpRequest());
                     } else if (message.hasSearchOpRequest()) {
-                        SearchAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getSearchOpRequest()).execute(connectorFacade);
+                        processor = SearchAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getSearchOpRequest());
                     } else if (message.hasSyncOpRequest()) {
-                        SyncAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getSyncOpRequest()).execute(connectorFacade);
+                        processor = SyncAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getSyncOpRequest());
                     } else if (message.hasSyncEventSubscriptionOpRequest()) {
-                        SyncEventSubscriptionApiOpImpl.createProcessor(messageId, socket,
-                                message.getSyncEventSubscriptionOpRequest()).execute(
-                                connectorFacade);
+                        processor = SyncEventSubscriptionApiOpImpl.createProcessor(messageId,
+                                socket, message.getSyncEventSubscriptionOpRequest());
                     } else if (message.hasTestOpRequest()) {
-                        TestAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getTestOpRequest()).execute(connectorFacade);
+                        processor = TestAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getTestOpRequest());
                     } else if (message.hasUpdateOpRequest()) {
-                        UpdateAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getUpdateOpRequest()).execute(connectorFacade);
+                        processor = UpdateAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getUpdateOpRequest());
                     } else if (message.hasValidateOpRequest()) {
-                        ValidateAsyncApiOpImpl.createProcessor(messageId, socket,
-                                message.getValidateOpRequest()).execute(connectorFacade);
+                        processor = ValidateAsyncApiOpImpl.createProcessor(messageId, socket,
+                                message.getValidateOpRequest());
                     } else {
                         socket.getRemoteConnectionContext().getRemoteConnectionGroup()
                                 .trySendMessage(
                                         MessagesUtil.createErrorResponse(messageId,
                                                 new ConnectorException("Unknown OperationRequest"))
                                                 .build());
+                    }
+
+                    // Registration is separate from construction so a
+                    // concurrently processed CancelOpRequest can never observe
+                    // a partially constructed processor; register() returns
+                    // false when a pending cancel already consumed the
+                    // request, in which case the operation must not start.
+                    if (null != processor && processor.register()) {
+                        processor.execute(connectorFacade);
                     }
                 } catch (Throwable t) {
                     logger.ok(t, "Failed handle OperationRequest {0}", messageId);


### PR DESCRIPTION
Part 1 of #112: the `CancelOpRequest` registration race.

## Problem

Operation execution is submitted to the shared pool and the `LocalRequest` registered itself in its constructor on that pool thread. A `CancelOpRequest` for the same message id processed before that registration removed nothing from `localRequests` and was **silently dropped**: the operation ran to completion (wasted work for search/sync), and for subscription operations — where the cancel is the unsubscribe mechanism — the subscription kept streaming events until the connection died.

Two related defects surfaced during the fix:

- `LocalRequest` published `this` from its constructor, so a concurrent cancel could observe a partially constructed processor (subclass fields still `null`) and NPE in `tryCancel()`.
- The subscription/batch processors assign their `Subscription` only inside `executeOperation`, so even a correctly delivered early cancel hit `subscription.close()` on `null`.

## Fix

- `RemoteConnectionGroup`: a cancel that finds no registered request is **parked** (request id → expiry, TTL 60 s) and applied when the operation registers. Park-then-lookup vs publish-then-check write the two maps in opposite order, so whichever side runs second sees the other — the cancel is never lost regardless of processing order. Request ids are never reused within a group, so a parked cancel can only match the operation it was sent for.
- `LocalRequest`: registration moved out of the constructor into an explicit `register()` that returns `false` when a parked cancel already consumed the request — the operation is then never started. `cancel()` is single-shot, making a duplicate delivery during the race harmless.
- `OpenICFServerAdapter.processOperationRequest`: all 16 dispatch branches now only build the processor; registration and execution happen in one place via `processor.register() && processor.execute(...)`.
- `ConnectorEventSubscriptionApiOpImpl`, `SyncEventSubscriptionApiOpImpl`, `BatchApiOpImpl`: the `Subscription` hand-over happens under a lock with a `cancelled` flag — a cancel racing with `subscribe()`/`executeBatch()` closes the subscription as soon as it exists instead of throwing NPE.

## Tests

New `LocalRequestRegistrationTest` covers: no registration from the constructor, register-then-cancel, cancel-before-registration is parked and applied, parked cancel does not affect other ids, cancel delivered exactly once, a deterministic replay of the interleaving where `receiveRequestCancel` delivers the cancel directly between the registration's `putIfAbsent` and its pending-cancel check, and a 1000-round two-thread stress test racing `register()` against `receiveRequestCancel(id)`.

Verified: connector-framework-rpc 13/13, connector-framework-server 25/25, connector-server-jetty 30/30.

## Compatibility note

`LocalRequest` subclasses are no longer registered by the constructor — call `register()` after construction and execute the operation only when it returns `true`. Out-of-tree subclasses relying on constructor registration compile unchanged but will not receive responses or cancel messages until updated. `RemoteConnectionGroup.receiveRequest` now returns `null` (and leaves the request unregistered) when a pending cancel already consumed the request.
