### PR TITLE
[#119] Migrate connector-server-jetty off deprecated org.eclipse.jetty.util.log

### DIFF
--- a/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketCreator.java
+++ b/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketCreator.java
@@ -29,8 +29,6 @@ import javax.security.auth.callback.NameCallback;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
@@ -40,10 +38,11 @@ import org.forgerock.openicf.framework.remote.ConnectionPrincipal;
 import org.forgerock.openicf.framework.remote.OpenICFServerAdapter;
 import org.forgerock.openicf.framework.remote.rpc.OperationMessageListener;
 import org.forgerock.openicf.framework.remote.rpc.WebSocketConnectionGroup;
+import org.identityconnectors.common.logging.Log;
 
 public class OpenICFWebSocketCreator implements JettyWebSocketCreator, Closeable {
 
-    private static final Logger logger = Log.getLogger(OpenICFWebSocketCreator.class);
+    private static final Log logger = Log.getLog(OpenICFWebSocketCreator.class);
 
     protected final ConcurrentMap<String, WebSocketConnectionGroup> globalConnectionGroups =
             new ConcurrentHashMap<String, WebSocketConnectionGroup>();
@@ -81,7 +80,9 @@ public class OpenICFWebSocketCreator implements JettyWebSocketCreator, Closeable
 
 
         if (null == authenticator) {
-            logger.info("Creating single 'anonymous' authenticator");
+            // Framework Log formats through MessageFormat, so single quotes
+            // must be doubled to survive.
+            logger.info("Creating single ''anonymous'' authenticator");
             this.authenticator = new Authenticator() {
                 @Override
                 public void authenticate(JettyServerUpgradeRequest request, JettyServerUpgradeResponse response, NameCallback callback) {

--- a/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketServletBase.java
+++ b/OpenICF-java-framework/connector-server-jetty/src/main/java/org/forgerock/openicf/framework/server/jetty/OpenICFWebSocketServletBase.java
@@ -18,7 +18,6 @@
 package org.forgerock.openicf.framework.server.jetty;
 
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -27,9 +26,6 @@ import javax.security.auth.callback.NameCallback;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.eclipse.jetty.util.log.Log;
-import org.eclipse.jetty.util.log.Logger;
-import org.eclipse.jetty.websocket.api.WebSocketPingPongListener;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
@@ -39,6 +35,7 @@ import org.forgerock.openicf.framework.ConnectorFrameworkFactory;
 import org.forgerock.openicf.framework.remote.ReferenceCountedObject;
 import org.forgerock.util.Utils;
 import org.identityconnectors.common.StringUtil;
+import org.identityconnectors.common.logging.Log;
 
 public class OpenICFWebSocketServletBase extends JettyWebSocketServlet {
 
@@ -49,7 +46,7 @@ public class OpenICFWebSocketServletBase extends JettyWebSocketServlet {
 
     private static final long serialVersionUID = 6089858120348026823L;
 
-    private static final Logger logger = Log.getLogger(OpenICFWebSocketServletBase.class);
+    private static final Log logger = Log.getLog(OpenICFWebSocketServletBase.class);
 
     private boolean privateConnectorFramework = false;
     private boolean privateExecutorService = false;
@@ -80,7 +77,7 @@ public class OpenICFWebSocketServletBase extends JettyWebSocketServlet {
                 // scheduler and framework go away.
                 websocketCreator.close();
             } catch (Throwable e) {
-                logger.warn(e);
+                logger.warn(e, "Failed to close the WebSocket creator");
             } finally {
                 websocketCreator = null;
             }
@@ -91,7 +88,7 @@ public class OpenICFWebSocketServletBase extends JettyWebSocketServlet {
                 executorService.shutdown();
                 executorService = null;
             } catch (Throwable e) {
-                logger.warn(e);
+                logger.warn(e, "Failed to shut the executor service down");
             }
         }
         if (privateConnectorFramework && connectorFramework != null) {
@@ -99,7 +96,7 @@ public class OpenICFWebSocketServletBase extends JettyWebSocketServlet {
                 connectorFramework.release();
                 connectorFramework = null;
             } catch (Exception e) {
-                logger.warn(e);
+                logger.warn(e, "Failed to release the connector framework");
             }
         }
     }


### PR DESCRIPTION
Fixes #119. Follow-up to #115.

## Problem

`OpenICFWebSocketCreator` and `OpenICFWebSocketServletBase` were the last two classes in `connector-server-jetty` still using `org.eclipse.jetty.util.log.Log`/`Logger` — deprecated in Jetty 10/11 (a shim over SLF4J) and removed in Jetty 12, so they block a future Jetty 12 upgrade. The `OpenICFWebSocket` endpoint added in #115 already uses the framework's own `org.identityconnectors.common.logging.Log`.

## Change

- Both classes now use `org.identityconnectors.common.logging.Log` (`Log.getLog(...)`), matching `OpenICFWebSocket`.
- The framework `Log` has no bare `warn(Throwable)` overload, so the three catch blocks in `OpenICFWebSocketServletBase.destroy()` gain messages: "Failed to close the WebSocket creator" / "Failed to shut the executor service down" / "Failed to release the connector framework".
- The framework `Log` formats through `MessageFormat`, which treats single quotes as escape characters — the quotes in `Creating single 'anonymous' authenticator` are doubled (`''anonymous''`) so the message survives intact.
- Drive-by: removed the unused `ByteBuffer` and `WebSocketPingPongListener` imports in `OpenICFWebSocketServletBase`.

No pom changes (`org.eclipse.jetty.util.StringUtil` is not deprecated and stays). After this change the module has no references to `org.eclipse.jetty.util.log` left.

Note for deployments: these few messages move from the Jetty/SLF4J route to the OpenICF `LogSpi` (`org.identityconnectors.common.logging.class`), consistent with the rest of the framework.

## Tests

Pure logging swap — no behavior change, no new tests. Existing suite covers the touched lines (creator constructor and lazy `configure()` path). Verified: connector-server-jetty 34/34.
